### PR TITLE
fix: declare Frappe v15 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # "frappe~=15.0.0" # Installed and managed by bench.
+    "frappe>=15,<16"
 ]
 
 [build-system]


### PR DESCRIPTION
**PR Description**

This PR fixes Frappe Framework v15 compatibility for the frappe-desk-theme app by declaring the supported framework version in pyproject.toml.

The main branch did not specify any Frappe dependency, which caused Frappe Cloud and Bench v15 to block installation and branch switching due to missing compatibility metadata.

**Issue**- [https://github.com/dhwani-ris/frappe_desk_theme/issues/8](https://github.com/dhwani-ris/frappe_desk_theme/issues/8)

**Solution**

This PR makes the app explicitly compatible with Frappe Framework v15 by adding the required dependency declaration.

The following change was made:

Declared Frappe framework compatibility in pyproject.toml using:
`
frappe>=15,<16
`

This ensures that Frappe Cloud and Bench can correctly validate and allow installation of the app on Frappe v15 environments.