### PR TITLE
Fix Frappe v15 breadcrumbs update patch

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
-  // Disable default 100-char (or 72-char) header length limit for commit messages
-  rules: {
-    "header-max-length": [0, "always", 100],
-  },
+	extends: ["@commitlint/config-conventional"],
+	// Disable default 100-char (or 72-char) header length limit for commit messages
+	rules: {
+		"header-max-length": [0, "always", 100],
+	},
 };

--- a/frappe_desk_theme/hooks.py
+++ b/frappe_desk_theme/hooks.py
@@ -30,7 +30,7 @@ app_include_css = "/assets/frappe_desk_theme/css/frappe_desk_theme.bundle.css"
 app_include_js = [
 	"/assets/frappe_desk_theme/js/frappe_desk_theme.bundle.js",
 	"/assets/frappe_desk_theme/js/sidebar/sidebar_override.bundle.js",
-	"/assets/frappe_desk_theme/js/sidebar/breadcrumb_override.bundle.js",
+	"/assets/frappe_desk_theme/js/sidebar/breadcrumb_override_patch.js",
 ]
 # include js, css files in header of web template
 web_include_css = "/assets/frappe_desk_theme/css/frappe_desk_theme.bundle.css"

--- a/frappe_desk_theme/public/js/sidebar/breadcrumb_override_patch.js
+++ b/frappe_desk_theme/public/js/sidebar/breadcrumb_override_patch.js
@@ -1,0 +1,88 @@
+function patch_breadcrumbs_update() {
+	if (!frappe.breadcrumbs || !frappe.breadcrumbs.update) {
+		setTimeout(patch_breadcrumbs_update, 100);
+		return;
+	}
+
+	const original_update = frappe.breadcrumbs.update;
+
+	frappe.breadcrumbs.update = function () {
+		const page = frappe.breadcrumbs.current_page();
+		const breadcrumbs = this.all[page];
+
+		if (!breadcrumbs) {
+			return original_update.call(this);
+		}
+
+		this.clear();
+
+		if (breadcrumbs.type === "Custom") {
+			this.set_custom_breadcrumbs(breadcrumbs);
+		} else {
+			let view = frappe.get_route()[0];
+			view = view ? view.toLowerCase() : null;
+
+			if (breadcrumbs.doctype || view === "list") {
+				const route = frappe.get_route();
+				const last = frappe.route_history.slice(-2)[0];
+				const from_workspace = last && last[0] === "Workspaces";
+
+				this.clear();
+
+				if (route[0] === "Form") {
+					if (from_workspace) {
+						this.append_breadcrumb_element(
+							`/app/${frappe.router.slug(last[1])}`,
+							__(last[1])
+						);
+					}
+					this.append_breadcrumb_element(
+						`/app/${frappe.router.slug(breadcrumbs.doctype)}`,
+						__(breadcrumbs.doctype)
+					);
+					const name = route[2];
+					this.append_breadcrumb_element(
+						`/app/${frappe.router.slug(breadcrumbs.doctype)}/${encodeURIComponent(
+							name
+						)}`,
+						__(name)
+					);
+					return this.toggle(true);
+				} else if (route[0] === "List") {
+					if (from_workspace) {
+						this.append_breadcrumb_element(
+							`/app/${frappe.router.slug(last[1])}`,
+							__(last[1])
+						);
+					}
+					this.append_breadcrumb_element(
+						`/app/${frappe.router.slug(breadcrumbs.doctype)}`,
+						__(breadcrumbs.doctype)
+					);
+					return this.toggle(true);
+				}
+			}
+
+			this.set_workspace_breadcrumb(breadcrumbs);
+
+			if (breadcrumbs.doctype && ["print", "form"].includes(view)) {
+				this.set_list_breadcrumb(breadcrumbs);
+				this.set_form_breadcrumb(breadcrumbs, view);
+			} else if (breadcrumbs.doctype && view == "dashboard-view") {
+				this.set_list_breadcrumb(breadcrumbs);
+			}
+		}
+
+		if (
+			breadcrumbs.workspace &&
+			frappe.workspace_map[breadcrumbs.workspace]?.app &&
+			frappe.workspace_map[breadcrumbs.workspace]?.app != frappe.current_app
+		) {
+			let app = frappe.workspace_map[breadcrumbs.workspace].app;
+			frappe.app.sidebar.apps_switcher.set_current_app(app);
+		}
+		this.toggle(true);
+	};
+}
+
+patch_breadcrumbs_update();


### PR DESCRIPTION
**Description:**
This PR patches frappe.breadcrumbs.update to handle a Frappe v15 behavior where this.all is not populated for Query Reports. Without this patch, opening query reports results in a TypeError when trying to read properties of undefined (e.g., HR, Projects).

**Changes included:**

Added a safe patch that preserves the original frappe.breadcrumbs.update for cases where this.all[page] is undefined.

Ensures breadcrumbs are properly displayed for Forms, Lists, and Dashboard views.

Compatible with Frappe v15 and does not affect other apps or previous behavior.

**Files modified:**

public/js/sidebar/breadcrumb_override_patch.js

**Issue fixed:**

Prevents Uncaught TypeError: Cannot read properties of undefined (reading 'HR') in Query Reports.

**Testing:**

Verified in Frappe v15 with Query Reports and standard List/Form views.

Breadcrumbs render correctly and no errors in console.