### PR TITLE
feat(theme): improve Desk readability with muted text and child-table header customization

### DIFF
--- a/frappe_desk_theme/frappe_desk_theme/doctype/desk_theme/desk_theme.json
+++ b/frappe_desk_theme/frappe_desk_theme/doctype/desk_theme/desk_theme.json
@@ -52,6 +52,7 @@
   "column_break_ojdd",
   "main_body_content_box_background_color",
   "main_body_content_box_text_color",
+  "muted_text_color",
   "sidebar_tab",
   "sidebar_section",
   "sidebar_background_color",
@@ -437,6 +438,12 @@
    "fieldname": "main_body_content_box_text_color",
    "fieldtype": "Color",
    "label": "Text Color"
+  },
+  {
+   "description": "Overrides Frappe's muted text tokens app-wide (field descriptions, read-only values, child-table headers, timestamps, empty states). Leave blank to keep Frappe's defaults.",
+   "fieldname": "muted_text_color",
+   "fieldtype": "Color",
+   "label": "Muted Text Color"
   },
   {
    "fieldname": "sidebar_section",

--- a/frappe_desk_theme/frappe_desk_theme/doctype/desk_theme/desk_theme.json
+++ b/frappe_desk_theme/frappe_desk_theme/doctype/desk_theme/desk_theme.json
@@ -74,6 +74,7 @@
   "column_break_xskf",
   "table_head_text_color",
   "table_body_text_color",
+  "wrap_child_table_headers",
   "disable_card_view_on_mobile_view",
   "disable_flex_card_content_on_mobile_view",
   "widgets_tab",
@@ -301,6 +302,13 @@
    "fieldname": "table_body_text_color",
    "fieldtype": "Color",
    "label": "Body Text Color"
+  },
+  {
+   "default": "0",
+   "description": "Let a long child-table column label wrap onto up to three lines instead of being cut off. Labels longer than three lines are still truncated, with the full text on hover.",
+   "fieldname": "wrap_child_table_headers",
+   "fieldtype": "Check",
+   "label": "Wrap Child Table Headers"
   },
   {
    "fieldname": "column_break_xskf",

--- a/frappe_desk_theme/public/css/frappe_desk_theme.bundle.css
+++ b/frappe_desk_theme/public/css/frappe_desk_theme.bundle.css
@@ -986,3 +986,43 @@ body.has-sticky-footer:not(:has(.main-section)) {
     right: 20px;
 }
 
+
+/* ==========================================================================
+   Wrapped child-table column headers  (opt-in: "Wrap Child Table Headers")
+   ==========================================================================
+   Frappe truncates grid header labels: the text sits in
+   `.static-area.ellipsis` (frappe/public/js/frappe/form/grid_row.js), and
+   `.ellipsis` is Frappe's global white-space:nowrap + text-overflow:ellipsis
+   utility. Releasing white-space alone is not enough -- `.grid-heading-row`
+   carries a fixed `height: 32px` (frappe/public/scss/common/grid.scss), so a
+   second line would be clipped. Both have to give.
+
+   Frappe's own wrap class, `grid-overflow-no-ellipsis`, is not reusable here:
+   it is applied only to DATA cells of Text/Small Text fields, never to the
+   header row.
+
+   Capped at three lines so grids on a form stay vertically aligned; anything
+   longer still ellipsises, and Frappe's own `title` attribute keeps the full
+   label available on hover. Everything is scoped under the body class, so a
+   site that has not enabled the setting is completely untouched.
+   ========================================================================== */
+body.fdt-wrap-grid-headers .form-grid .grid-heading-row {
+	height: auto !important;
+	min-height: 32px;
+}
+
+body.fdt-wrap-grid-headers .form-grid .grid-heading-row .grid-static-col {
+	height: auto !important;
+	display: flex;
+	align-items: center;
+}
+
+body.fdt-wrap-grid-headers .form-grid .grid-heading-row .static-area.ellipsis {
+	white-space: normal;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	line-height: 1.3;
+}

--- a/frappe_desk_theme/public/js/frappe_desk_theme.bundle.js
+++ b/frappe_desk_theme/public/js/frappe_desk_theme.bundle.js
@@ -1,4 +1,21 @@
 /**
+ * Frappe's own muted-text tokens, driven by the "Muted Text Color" setting.
+ * These are Frappe's variables, not this app's private namespace -- Frappe uses
+ * them across field descriptions, read-only values, child-table headers,
+ * timestamps, empty states and sidebar sub-items, so setting them once darkens
+ * all of it. Kept in one place because setCSSVariables() sets them and
+ * clearCSSVariables() must remove exactly the same list.
+ */
+const MUTED_TEXT_VARIABLES = [
+	"--text-muted",
+	"--text-light",
+	"--disabled-text-color",
+	"--ink-gray-4",
+	"--ink-gray-5",
+	"--ink-gray-6",
+];
+
+/**
  * FrappeDeskTheme - Main theme management class
  * Handles loading, applying, and managing custom theme configurations for Frappe Desk
  * Supports dynamic theme changes, user role-based hiding, and real-time DOM updates
@@ -354,6 +371,7 @@ class FrappeDeskTheme {
 			"--footer-link-hover-color",
 			"--carousel-fade-opacity",
 			"--login-bg-carousel-image",
+			...MUTED_TEXT_VARIABLES,
 		];
 
 		// Remove each CSS variable from document root
@@ -618,6 +636,19 @@ class FrappeDeskTheme {
 		}
 		if (theme.main_body_content_box_text_color) {
 			root.style.setProperty("--content-text-color", theme.main_body_content_box_text_color);
+		}
+
+		// Muted text: map onto Frappe's OWN tokens rather than this app's private
+		// namespace. Frappe paints field descriptions, read-only values, child-table
+		// headers, timestamps and empty states from these, so one setting reaches all
+		// of them. --text-color and --heading-color are deliberately left alone: they
+		// already resolve dark (#383838 / #171717) and overriding them would flatten
+		// the heading/body hierarchy.
+		// Guarded on a non-empty value so a site that has not set it is untouched.
+		if (theme.muted_text_color) {
+			MUTED_TEXT_VARIABLES.forEach((variable) => {
+				root.style.setProperty(variable, theme.muted_text_color);
+			});
 		}
 
 		// Sidebar customization

--- a/frappe_desk_theme/public/js/frappe_desk_theme.bundle.js
+++ b/frappe_desk_theme/public/js/frappe_desk_theme.bundle.js
@@ -15,6 +15,9 @@ const MUTED_TEXT_VARIABLES = [
 	"--ink-gray-6",
 ];
 
+/** Body class that opts a site into wrapped child-table column headers. */
+const WRAP_GRID_HEADERS_CLASS = "fdt-wrap-grid-headers";
+
 /**
  * FrappeDeskTheme - Main theme management class
  * Handles loading, applying, and managing custom theme configurations for Frappe Desk
@@ -378,6 +381,8 @@ class FrappeDeskTheme {
 		cssVariables.forEach((variable) => {
 			root.style.removeProperty(variable);
 		});
+
+		document.body.classList.remove(WRAP_GRID_HEADERS_CLASS);
 	}
 
 	/**
@@ -650,6 +655,13 @@ class FrappeDeskTheme {
 				root.style.setProperty(variable, theme.muted_text_color);
 			});
 		}
+
+		// Child-table header wrapping is layout, not colour, so it rides a body class
+		// instead of a custom property.
+		document.body.classList.toggle(
+			WRAP_GRID_HEADERS_CLASS,
+			!!theme.wrap_child_table_headers
+		);
 
 		// Sidebar customization
 		if (theme.sidebar_background_color) {


### PR DESCRIPTION
## Summary

This PR enhances the Desk Theme with improved control over muted text visibility and long child-table column headers. Both features are opt-in and preserve the existing appearance until explicitly enabled.

## Changes Included

### Muted Text Color

* Added a **Muted Text Color** theme setting.
* Maps the configured color to Frappe's existing text tokens including:

  * `--text-muted`
  * `--text-light`
  * `--disabled-text-color`
  * `--ink-gray-4`
  * `--ink-gray-5`
  * `--ink-gray-6`
* Improves readability of field descriptions, read-only values, child-table headers, timestamps, empty states, and sidebar sub-items.
* Excludes `--text-color` and `--heading-color` to preserve the existing visual hierarchy.
* Added cleanup support so clearing the setting removes all previously applied CSS variables.
* No default value is introduced, so existing sites remain unchanged unless configured.

### Wrap Child Table Headers

* Added an opt-in **Wrap Child Table Headers** setting.
* Allows long child-table column labels to wrap across up to three lines instead of being truncated immediately.
* Increased header height dynamically when wrapping is enabled.
* Preserved Frappe's existing truncation behavior for data cells.
* Added scoped styling using the `fdt-wrap-grid-headers` body class.
* Automatically removes the class when the setting is disabled to fully restore the default layout.
* Preserved the full header text through the existing hover tooltip behavior.

### Validation

* Verified both features on the ATMA/UAT environment.
* Confirmed existing styling remains unchanged when the new settings are left empty or disabled.
* Confirmed custom values and header wrapping are correctly applied and fully reverted when cleared or disabled.

## Impact

* Improves readability across the Frappe Desk interface.
* Gives administrators more control over muted text visibility.
* Makes long child-table column labels easier to read without affecting table data-cell behavior.
* Maintains backward compatibility through opt-in settings and complete cleanup when disabled.
